### PR TITLE
Make DEBUG setting configurable via environment variable

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() == 'true'
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This pull request addresses the issue where the DEBUG setting was hardcoded to True. The DEBUG setting is now configurable via the DJANGO_DEBUG environment variable, defaulting to False for production safety. This allows flexible configuration between development and production environments.

- Changed DEBUG assignment to use os.environ.get('DJANGO_DEBUG', 'False').
- Ensures DEBUG is False unless explicitly set to True in the environment.

Closes: Hardcoded DEBUG issue.