### PR TITLE
[SECURITY] Use environment variable for DEBUG mode (Fixes #7)

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() in ('true', '1', 'yes')
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This pull request addresses Issue #7 by replacing the hardcoded DEBUG = True setting in myproject/settings.py with an environment variable-based configuration:

- DEBUG is now set using os.environ.get('DJANGO_DEBUG', 'False'), which reads the value from the DJANGO_DEBUG environment variable. This prevents accidental exposure of sensitive debug information in production environments.

**Security Improvement:**
- Ensures DEBUG mode is not enabled in production unless explicitly set.
- Follows Django security best practices.

Closes #7.