### PR TITLE
Fix #7: Make DEBUG configurable via DJANGO_DEBUG environment variable

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False') == 'True'
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This pull request addresses Issue #7 by removing the hardcoded 'DEBUG = True' in myproject/settings.py and replacing it with an environment variable-based configuration:

DEBUG = os.environ.get('DJANGO_DEBUG', 'False') == 'True'

This change improves security by ensuring DEBUG mode is not enabled in production unless explicitly set via the DJANGO_DEBUG environment variable.

- Updated: myproject/settings.py
- Fixes: #7

Please review and merge.