### PR TITLE
Fix #5: Secure SECRET_KEY using environment variable

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -10,6 +10,7 @@ https://docs.djangoproject.com/en/4.x/topics/settings/
 
 import os
 from pathlib import Path
+from django.core.exceptions import ImproperlyConfigured
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -18,7 +19,13 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.x/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'your-secret-key'
+def get_secret_key():
+    secret = os.environ.get('DJANGO_SECRET_KEY')
+    if not secret:
+        raise ImproperlyConfigured('The DJANGO_SECRET_KEY environment variable is not set!')
+    return secret
+
+SECRET_KEY = get_secret_key()
 
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True


### PR DESCRIPTION
This pull request resolves issue #5 by enhancing the security of the Django SECRET_KEY configuration.

- The hardcoded weak SECRET_KEY placeholder is removed.
- SECRET_KEY is now loaded from the DJANGO_SECRET_KEY environment variable using a helper function.
- If the environment variable is not set, an ImproperlyConfigured exception is raised, preventing insecure deployments.

This change ensures that SECRET_KEY is never exposed in source code and must be securely provided in the deployment environment.

Developers: Please set the DJANGO_SECRET_KEY environment variable in your local and production environments before deploying this update.