### PR TITLE
Fix Issue #7: Use environment variable for DEBUG setting

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False') == 'True'
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This PR resolves Issue #7 by updating the DEBUG setting in settings.py to use the DJANGO_DEBUG environment variable instead of being hardcoded to True. This enhances production safety by preventing accidental exposure of sensitive debug information. 

- Replaced DEBUG = True with DEBUG = os.environ.get('DJANGO_DEBUG', 'False') == 'True'
- Referenced Issue #7 in the commit message.

Please review and merge.