### PR TITLE
Fix Issue #7: Use environment variable for DEBUG instead of hardcoded True

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() in ('true', '1', 'yes')
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This pull request addresses Issue #7 by updating the settings.py file to control the DEBUG setting using the DJANGO_DEBUG environment variable instead of hardcoding it to True. This change improves security by ensuring sensitive debug information is not exposed in production environments. 

- DEBUG now reads from the DJANGO_DEBUG environment variable and defaults to False.
- Hardcoded DEBUG = True has been removed.

Closes #7.