### PR TITLE
Fix #7: Use environment variable for DEBUG instead of hardcoding to True

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False') == 'True'
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This pull request resolves issue #7 by updating the DEBUG setting in myproject/settings.py.

- DEBUG is now set using the environment variable DJANGO_DEBUG instead of being hardcoded to True.
- This improves security by preventing sensitive debug information from being exposed in production environments.

**Old code:**
```python
DEBUG = True
```

**New code:**
```python
DEBUG = os.environ.get('DJANGO_DEBUG', 'False') == 'True'
```

Please review and merge. This change is critical for production safety.