### PR TITLE
[SECURITY] Make DEBUG configurable via environment variable (Fixes #7)

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() in ('true', '1', 'yes')
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This pull request addresses Issue #7: DEBUG mode hardcoded to True - unsafe for production.

- The DEBUG setting in myproject/settings.py is now configurable via the DJANGO_DEBUG environment variable.
- By default, DEBUG is set to False, ensuring safe production deployment.
- This change prevents accidental exposure of sensitive information in production environments.

Please review and merge to enhance the security of the application.