### PR TITLE
Fix Issue #7: Make DEBUG configurable via environment variable

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False') == 'True'
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This pull request addresses Issue #7 by updating myproject/settings.py:

- The DEBUG setting is now configurable via the DJANGO_DEBUG environment variable instead of being hardcoded to True.
- This change improves security by preventing accidental deployment with DEBUG enabled in production environments.

**How it works:**
- Set the environment variable DJANGO_DEBUG to 'True' or 'False' to control the DEBUG mode.

Closes #7.

Please review and merge. Thank you!