### PR TITLE
Fix #7: Use environment variable for DEBUG setting for improved security

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() in ('true', '1', 'yes')
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This pull request addresses issue #7 by removing the hardcoded DEBUG = True setting in myproject/settings.py. DEBUG is now set based on the DJANGO_DEBUG environment variable, defaulting to False if not set. This change enhances security by preventing accidental deployment with DEBUG mode enabled in production environments.

- Replaces DEBUG = True with environment-based configuration
- References issue #7

Please review and merge to improve production safety.