### PR TITLE
Fix: Use environment variable for DEBUG setting (closes #7)

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() == 'true'
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This PR addresses issue #7 by updating the DEBUG setting in myproject/settings.py.

- DEBUG is no longer hardcoded to True. Instead, it is now set using the DJANGO_DEBUG environment variable, defaulting to False for production safety.
- This change improves security by preventing accidental deployment with DEBUG enabled.
- Added logic: DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() == 'true'
- Ensured import os is present.

Please review and merge. This closes #7.