### PR TITLE
[SECURITY] Refactor DEBUG setting to use environment variable (Fix Issue #7)

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False') == 'True'
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This pull request addresses Issue #7: DEBUG mode hardcoded to True - unsafe for production.

Changes made:
- Refactored the DEBUG setting in settings.py to use an environment variable (os.environ.get('DJANGO_DEBUG', 'False') == 'True') instead of being hardcoded to True.
- Ensured the default value is False for production safety.
- Added/confirmed import for os module.

This improves security by preventing sensitive debug information from being exposed in production environments. Please review and merge.