### PR TITLE
Set DEBUG = False for production (fixes ABC-25)

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = False
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This pull request addresses issue ABC-25 by setting DEBUG = False in myproject/settings.py. This change ensures that the application does not run in debug mode in production, improving security and performance.

- Changed: DEBUG = True → DEBUG = False

Please review and merge. Closes ABC-25.