### PR TITLE
[SECURITY FIX] Make DEBUG configurable via environment variable

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() in ('true', '1', 'yes')
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This pull request addresses Issue #7 by removing the hardcoded `DEBUG = True` in `myproject/settings.py`.

### Changes Made:
- Replaced hardcoded DEBUG value with environment variable-based configuration:
  ```python
  DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() in ('true', '1', 'yes')
  ```
- This ensures DEBUG mode can be controlled via environment variables, preventing sensitive data exposure in production.

### Security Impact:
- Eliminates the risk of exposing debug information in production.
- Allows flexible configuration for different environments.

Please review and merge to enhance security.