### PR TITLE
Fix: Use environment variable for DEBUG setting

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.getenv('DJANGO_DEBUG', 'False').lower() == 'true'
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This pull request addresses GitHub issue #7 by removing the hardcoded DEBUG=True value in `myproject/settings.py`.

### Changes Made:
- DEBUG is now set based on the environment variable `DJANGO_DEBUG`.
- Defaults to `False` unless explicitly set to `true`.

### Security Impact:
- Prevents accidental exposure of sensitive information in production.
- Allows flexible configuration for different environments.

### Testing:
- Verified that DEBUG is `True` when `DJANGO_DEBUG=true`.
- Verified that DEBUG is `False` when unset or set to any other value.

This change improves security and aligns with Django deployment best practices.