### PR TITLE
Fix: Remove hardcoded DEBUG=True and use environment variable for configuration

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -21,7 +21,8 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = 'your-secret-key'
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+# Use environment variable to control DEBUG mode
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() == 'true'
 
 ALLOWED_HOSTS = ['*']
 


### PR DESCRIPTION
This PR addresses GitHub issue #7 by removing the hardcoded `DEBUG=True` in `myproject/settings.py`.

### Changes Made:
- Implemented environment variable-based configuration for DEBUG.
- Default DEBUG to `False` in production.
- Ensures sensitive debug information is not exposed in production environments.

**Testing:**
- Verified DEBUG mode can be toggled via `DJANGO_DEBUG` environment variable.
- Default behavior is secure for production.

This change improves security and aligns with Django's deployment checklist.