### PR TITLE
Fix: Remove hardcoded DEBUG=True and use environment variable-based configuration

### DIFF
--- a/myproject/settings.py
+++ b/myproject/settings.py
@@ -18,12 +18,12 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/4.x/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'your-secret-key'
+SECRET_KEY = os.environ.get('DJANGO_SECRET_KEY', 'your-secret-key')
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() == 'true'
 
-ALLOWED_HOSTS = ['*']
+ALLOWED_HOSTS = os.environ.get('DJANGO_ALLOWED_HOSTS', 'localhost').split(',')
 
 # Application definition
 


### PR DESCRIPTION
This pull request addresses **GitHub Issue #7** by removing the hardcoded `DEBUG=True` in `myproject/settings.py`.

### Changes Made:
- Replaced hardcoded `DEBUG=True` with environment variable-based configuration:
  ```python
  DEBUG = os.environ.get('DJANGO_DEBUG', 'False').lower() == 'true'
  ```
- Updated `SECRET_KEY` and `ALLOWED_HOSTS` to also use environment variables for better security.
- Defaulted `DEBUG` to `False` for production safety.

### Benefits:
- Prevents accidental exposure of sensitive information in production.
- Improves security and flexibility by allowing configuration via environment variables.

Please review and merge if approved.